### PR TITLE
Cicd/add auto deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,125 @@
+# Deploy the site to AWS S3 on a push to specific branches
+
+name: Deploy
+
+permissions:
+  id-token: write
+  contents: read
+
+on:
+  push:
+    branches:
+    - main
+    - develop
+    - cicd/add-auto-deployment
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE: 20
+
+jobs:
+  define-environment:
+    name: Set environment
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set the environment based on the branch
+        id: define_environment
+        run: |
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            echo "env_name=production" >> $GITHUB_OUTPUT
+          elif [ "${{ github.ref }}" = "refs/heads/develop" ]; then
+            echo "env_name=staging" >> $GITHUB_OUTPUT
+          elif [ "${{ github.ref }}" = "refs/heads/cicd/add-auto-deployment" ]; then
+            echo "env_name=staging" >> $GITHUB_OUTPUT
+          fi
+      - name: Print the environment
+        run: echo "The environment is ${{ steps.define_environment.outputs.env_name }}"
+
+    outputs:
+      env_name: ${{ steps.define_environment.outputs.env_name }}
+
+  build:
+    runs-on: ubuntu-latest
+    needs: define-environment
+    environment: ${{ needs.define-environment.outputs.env_name }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Use Node.js ${{ env.NODE }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE }}
+
+      - name: Cache node_modules
+        uses: actions/cache@v2
+        id: cache-node-modules
+        with:
+          path: |
+            node_modules
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package.json') }}
+
+      - name: Cache dist
+        uses: actions/cache@v2
+        id: cache-dist
+        with:
+          path: dist
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.workflow }}-${{ github.sha }}
+
+
+      - name: Build website
+        env:
+          GOOGLE_TAG_MANAGER_ID: ${{secrets.GOOGLE_TAG_MANAGER_ID}}
+          GOOGLE_TAG_AUTH: ${{secrets.GOOGLE_TAG_AUTH}}
+          GOOGLE_TAG_PREVIEW: ${{secrets.GOOGLE_TAG_PREVIEW}}
+        run: npm run build  # vars.SUBPATH should include the preceeding slash /
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [build, define-environment]
+    environment: ${{ needs.define-environment.outputs.env_name }}
+    steps:
+      # See comment on checks.yml - prep step
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Restore node_modules
+        uses: actions/cache@v2
+        id: cache-node-modules
+        with:
+          path: |
+            node_modules
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package.json') }}
+
+      - name: Restore dist cache
+        uses: actions/cache@v2
+        id: cache-dist
+        with:
+          path: dist
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.workflow }}-${{ github.sha }}
+
+      - name: Use Node.js ${{ env.NODE }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE }}
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.DEPLOYMENT_ROLE_ARN }}
+          role-session-name: "mobile-climate-${{ needs.define-environment.outputs.env_name }}"
+          aws-region: "us-west-2"
+
+      - name: Deploy to S3 Production
+        run: |
+          aws s3 sync ./dist s3://${{ secrets.S3_BUCKET }}${{ vars.SUBPATH }} --cache-control max-age=30,must-revalidate,s-maxage=604800 --delete
+
+      - name: Request Invalidation to AWS Cloudfront
+        uses: oneyedev/aws-cloudfront-invalidation@v1
+        with:
+          distribution-id: ${{ secrets.CF_DISTRIBUTION_ID }}
+          paths: |
+            ${{ vars.SUBPATH }}*

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,7 +75,9 @@ jobs:
           GOOGLE_TAG_MANAGER_ID: ${{secrets.GOOGLE_TAG_MANAGER_ID}}
           GOOGLE_TAG_AUTH: ${{secrets.GOOGLE_TAG_AUTH}}
           GOOGLE_TAG_PREVIEW: ${{secrets.GOOGLE_TAG_PREVIEW}}
-        run: npm run build  # vars.SUBPATH should include the preceeding slash /
+        run: |
+          npm install
+          npm run build  # vars.SUBPATH should include the preceeding slash /
 
   deploy:
     runs-on: ubuntu-latest

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="src\assets\eic.svg" />
+    <link rel="icon" type="image/svg+xml" href="./src/assets/eic.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -11,6 +11,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
+    <script type="module" src="./src/main.jsx"></script>
   </body>
 </html>

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -153,7 +153,7 @@ export default function Home() {
         config.datasets.forEach((dataset) => {
             dataset.variables.forEach((variable, index) => {
                 const timestamp = Date.now();
-                const videoUrl = `${variable.video}?cb=${timestamp}`;
+                const videoUrl = `${import.meta.env.BASE_URL.replace(/\/$/, "")}${variable.video}?cb=${timestamp}`;
 
                 const element = new VideoElement({
                     video: videoUrl,
@@ -177,7 +177,7 @@ export default function Home() {
                 mediaLayer.opacity = variable.name === 'SSP126' ? 1 : 0;
 
                 console.log(
-                    `Initializing video for: ${variable.name}`,
+                    `Initializing video for: ${import.meta.env.BASE_URL}${variable.name}`,
                     variable.video
                 );
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,5 +3,6 @@ import react from '@vitejs/plugin-react'
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: './',
   plugins: [react()],
 })


### PR DESCRIPTION
# Changes
- Adds a GitHub actions workflow for auto deployment on push to branches
  - develop -> deploys to staging.earth.gov/mobile-climate-mapper
  - main -> deploys to earth.gov/mobile-climate-mapper
- Updates vite config + video path to support deployment in a subfolder

I've also added `staging` and `production` environments in the repository with all the required secrets and variables, so it should work smoothly.

The cloudfront setup is manual. I've created a behavior for `/mobile-climate-mapper*` which is routed to the s3 bucket. if we need to update the subpath, we'll need to update the SUBPATH env var in the GitHub environments to the new subpath and manually update the cloudfront behavior to the new subpath.

I've also setup the production cloudfront with the same subpath already and also secured it with username/password (it's in [slack](https://teamdsig.slack.com/archives/C063GD0NYP8/p1727294452127559?thread_ts=1727214927.316699&cid=C063GD0NYP8)) for now.