### PR TITLE
Add VITE_GIS_TOKEN to the image service request

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,6 +72,8 @@ jobs:
           GOOGLE_TAG_MANAGER_ID: ${{secrets.GOOGLE_TAG_MANAGER_ID}}
           GOOGLE_TAG_AUTH: ${{secrets.GOOGLE_TAG_AUTH}}
           GOOGLE_TAG_PREVIEW: ${{secrets.GOOGLE_TAG_PREVIEW}}
+          VITE_GIS_TOKEN: {{secrets.GIS_TOKEN}}
+          VITE_REFERER: {{vars.GIS_REFERER}}
         run: |
           npm install
           npm run build

--- a/src/config.json
+++ b/src/config.json
@@ -13,7 +13,7 @@
                     "mobileVideo": "./monthly_max_ssp126_max12_8192_512x256.mp4",
                     "fallbackImage": "./first_frame_ssp126.png",
                     "service":
-                    "https://gis.earthdata.nasa.gov/eic/rest/services/tasmax_yearly_median/ImageServer",
+                    "https://gis.earthdata.nasa.gov/eictester/rest/services/tasmax_yearly_median/ImageServer",
                     "datetimeRange": ["1950-01-31T00:00:00Z", "2100-12-31T23:59:59Z"],
                     "wcs": false,
                     "active": true,
@@ -45,7 +45,7 @@
                     "mobileVideo": "./monthly_max_ssp245_max12_8192_1024x512.mp4",
                     "fallbackImage": "./first_frame_ssp245.png",
                     "service":
-                    "https://gis.earthdata.nasa.gov/eic/rest/services/tasmax_yearly_median/ImageServer",
+                    "https://gis.earthdata.nasa.gov/eictester/rest/services/tasmax_yearly_median/ImageServer",
                     "datetimeRange": ["1950-01-31T00:00:00Z", "2100-12-31T23:59:59Z"],
                     "wcs": false,
                     "active": true,
@@ -77,7 +77,7 @@
                     "mobileVideo": "./monthly_max_ssp370_max12_8192_512x256.mp4",
                     "fallbackImage": "./first_frame_ssp370.png",
                     "service":
-                    "https://gis.earthdata.nasa.gov/eic/rest/services/tasmax_yearly_median/ImageServer",
+                    "https://gis.earthdata.nasa.gov/eictester/rest/services/tasmax_yearly_median/ImageServer",
                     "datetimeRange": ["1950-01-31T00:00:00Z", "2100-12-31T23:59:59Z"],
                     "wcs": false,
                     "active": true,
@@ -109,7 +109,7 @@
                     "fallbackImage": "./first_frame_ssp585.png",
                     "variable": "tasmax_ssp585",
                     "service":
-                    "https://gis.earthdata.nasa.gov/eic/rest/services/tasmax_yearly_median/ImageServer",
+                    "https://gis.earthdata.nasa.gov/eictester/rest/services/tasmax_yearly_median/ImageServer",
                     "datetimeRange": ["1950-01-31T00:00:00Z", "2100-12-31T23:59:59Z"],
                     "wcs": false,
                     "active": true,

--- a/src/config.json
+++ b/src/config.json
@@ -13,7 +13,7 @@
                     "mobileVideo": "./monthly_max_ssp126_max12_8192_512x256.mp4",
                     "fallbackImage": "./first_frame_ssp126.png",
                     "service":
-                    "https://gis.earthdata.nasa.gov/eictester/rest/services/tasmax_yearly_median/ImageServer",
+                    "https://gis.earthdata.nasa.gov/eic/rest/services/tasmax_yearly_median/ImageServer",
                     "datetimeRange": ["1950-01-31T00:00:00Z", "2100-12-31T23:59:59Z"],
                     "wcs": false,
                     "active": true,
@@ -45,7 +45,7 @@
                     "mobileVideo": "./monthly_max_ssp245_max12_8192_1024x512.mp4",
                     "fallbackImage": "./first_frame_ssp245.png",
                     "service":
-                    "https://gis.earthdata.nasa.gov/eictester/rest/services/tasmax_yearly_median/ImageServer",
+                    "https://gis.earthdata.nasa.gov/eic/rest/services/tasmax_yearly_median/ImageServer",
                     "datetimeRange": ["1950-01-31T00:00:00Z", "2100-12-31T23:59:59Z"],
                     "wcs": false,
                     "active": true,
@@ -77,7 +77,7 @@
                     "mobileVideo": "./monthly_max_ssp370_max12_8192_512x256.mp4",
                     "fallbackImage": "./first_frame_ssp370.png",
                     "service":
-                    "https://gis.earthdata.nasa.gov/eictester/rest/services/tasmax_yearly_median/ImageServer",
+                    "https://gis.earthdata.nasa.gov/eic/rest/services/tasmax_yearly_median/ImageServer",
                     "datetimeRange": ["1950-01-31T00:00:00Z", "2100-12-31T23:59:59Z"],
                     "wcs": false,
                     "active": true,
@@ -109,7 +109,7 @@
                     "fallbackImage": "./first_frame_ssp585.png",
                     "variable": "tasmax_ssp585",
                     "service":
-                    "https://gis.earthdata.nasa.gov/eictester/rest/services/tasmax_yearly_median/ImageServer",
+                    "https://gis.earthdata.nasa.gov/eic/rest/services/tasmax_yearly_median/ImageServer",
                     "datetimeRange": ["1950-01-31T00:00:00Z", "2100-12-31T23:59:59Z"],
                     "wcs": false,
                     "active": true,

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -34,11 +34,12 @@ export const handleImageServiceRequest = async (event, variable, setChartData, s
 
   try {
     const token = import.meta.env.VITE_GIS_TOKEN ?? '';
+    const referer = import.meta.env.VITE_REFERER ?? 'https://earth.gov';
     const response = await fetch(url.toString(), {
       method: 'GET',
       headers: {
         'X-Esri-Authorization': `Bearer ${token}`,
-        'Referer': 'https://earthdata.gov',
+        'Referer': `${referer}`,
       }
     });
     const results = await response.json();

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -33,7 +33,7 @@ export const handleImageServiceRequest = async (event, variable, setChartData, s
   };
 
   try {
-    const token = import.meta.env.VITE_GIS_TOKEN;
+    const token = import.meta.env.VITE_GIS_TOKEN ?? '';
     const response = await fetch(url.toString(), {
       method: 'GET',
       headers: {

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -32,8 +32,16 @@ export const handleImageServiceRequest = async (event, variable, setChartData, s
     }),
   };
 
+  const token = process.env.GIS_TOKEN;
+
   try {
-    const response = await fetch(url.toString(), { method: 'GET' });
+    const response = await fetch(url.toString(), {
+      method: 'GET',
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Referer': 'https://earthdata.gov',
+      }
+    });
     const results = await response.json();
     // const results = mockData; // Uncomment this line to use mockData during testing
 

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -37,7 +37,7 @@ export const handleImageServiceRequest = async (event, variable, setChartData, s
     const response = await fetch(url.toString(), {
       method: 'GET',
       headers: {
-        'Authorization': `Bearer ${token}`,
+        'X-Esri-Authorization': `Bearer ${token}`,
         'Referer': 'https://earthdata.gov',
       }
     });

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -32,9 +32,8 @@ export const handleImageServiceRequest = async (event, variable, setChartData, s
     }),
   };
 
-  const token = process.env.GIS_TOKEN;
-
   try {
+    const token = import.meta.env.VITE_GIS_TOKEN;
     const response = await fetch(url.toString(), {
       method: 'GET',
       headers: {


### PR DESCRIPTION
The PR adds a VITE_GIS_TOKEN to the image service request. Currently no token is set as an .env variable, so the image service errors out. 

@amarouane-ABDELHAK Can we use the name `VITE_GIS_TOKEN` for the env variable? I think that might have been the reason why you got errors on Friday from the service. 

Issue to improve the rest of the error handling post-launch: https://github.com/NASA-IMPACT/EIC-Mobile/issues/58