### PR TITLE
chore: bump Node.js to v22

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NODE: 20
+  NODE: 22
 
 jobs:
   define-environment:


### PR DESCRIPTION
Node 20 hits end-of-life in April 2026, which is this month. Node 22 is the current LTS (Long Term Support) and will be supported until April 2027